### PR TITLE
Loosing semantic but matching package_linter mess

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "A libre and federated social network, fork of Mastodon.",
         "fr": "Un réseau social libre et fédéré, scission de Mastodon."
     },
-    "version": "3.4.0-rc2~ynh1",
+    "version": "3.4.0~ynh1",
     "url": "https://github.com/glitch-soc/mastodon",
     "upstream": {
         "license": "free",


### PR DESCRIPTION
## Problem

- Package_linter hate words in version number

## Solution

- Remove "-rc2'

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
