### PR TITLE
Update label for max_display_name_chars

### DIFF
--- a/config_panel.toml
+++ b/config_panel.toml
@@ -6,7 +6,7 @@ services = ["__APP__-web", "__APP__-sidekiq", "__APP__-streaming"]
 
     [main.customization]
     name = "Customization"
-        
+
         [main.customization.max_toot_chars]
         ask = "Maximum allowed character count in a toot"
         type = "number"
@@ -32,7 +32,7 @@ services = ["__APP__-web", "__APP__-sidekiq", "__APP__-streaming"]
         bind = ":__FINALPATH__/live/.env.production"
 
         [main.customization.max_display_name_chars]
-        ask = "Maximum allowed bio characters"
+        ask = "Maximum allowed display name characters"
         type = "number"
         example = "30"
         bind = ":__FINALPATH__/live/.env.production"


### PR DESCRIPTION
## Problem

- There was a slight typo with the `max_display_name_chars` option.

## Solution

- I updated the label for the option. :smiley: 

## PR Status

- [X] Code finished and ready to be reviewed/tested

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)