### PR TITLE
Fix install process

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -132,6 +132,7 @@ pushd "$install_dir/live"
 	# This export might be removed in yunohost 12
 	COREPACK_ENABLE_DOWNLOAD_PROMPT=0 yarn install
 	echo "SAFETY_ASSURED=1">> "$config"
+	ynh_exec_warn_less ynh_exec_as "$app" RAILS_ENV=production COREPACK_ENABLE_DOWNLOAD_PROMPT=0 "$ynh_ruby_load_path" "$ld_preload" bin/bundle exec rails db:encryption:init --quiet
 	ynh_exec_warn_less ynh_exec_as "$app" RAILS_ENV=production COREPACK_ENABLE_DOWNLOAD_PROMPT=0 "$ynh_ruby_load_path" "$ld_preload" bin/bundle exec rails db:migrate --quiet
 	ynh_exec_warn_less ynh_exec_as "$app" RAILS_ENV=production COREPACK_ENABLE_DOWNLOAD_PROMPT=0 "$ynh_ruby_load_path" "$ld_preload" bin/bundle exec rails assets:precompile --quiet
 	# Generate vapid keys


### PR DESCRIPTION
## Problem
Since Mastodon 4.3.0, 3 environment variables related to database encryption need to be set [https://docs.joinmastodon.org/admin/config/#db-encryption-support](https://docs.joinmastodon.org/admin/config/#db-encryption-support). The current install script fails because the variables are not present.

## Solution
These keys can be generated by running `rails db:encryption:init` before other rails commands

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
