### PR TITLE
Fix install script and upgrade to 2025.03.08

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Glitch-Soc"
 description.en = "Libre and federated social network, fork of Mastodon"
 description.fr = "Réseau social libre et fédéré, scission de Mastodon"
 
-version = "2024.12.29~ynh1"
+version = "2025.03.08~ynh1"
 
 maintainers = ["Tagada"]
 
@@ -50,8 +50,8 @@ ram.runtime = "500M"
 [resources]
     [resources.sources]
         [resources.sources.main]
-        url = "https://github.com/glitch-soc/mastodon/archive/b7afca0f053a74518c2c0742907e8e4f7d92d709.tar.gz"
-        sha256 = "b3895882044fc369d9e5a7570526af4173864a0184b7217c40e2186096bf6912"
+        url = "https://github.com/glitch-soc/mastodon/archive/248a0541c0084527ea56a413028ace6d3ec14c60.tar.gz"
+        sha256 = "14b8f2f86b5b5e558702d35bd30228e368fc7430feb1452b39791b773bd12dd2"
 
         autoupdate.strategy = "latest_github_commit"
 

--- a/scripts/install
+++ b/scripts/install
@@ -142,6 +142,7 @@ pushd "$install_dir/live"
 	COREPACK_ENABLE_DOWNLOAD_PROMPT=0 yarn install
 	echo "SAFETY_ASSURED=1">> "$config"
 	ynh_exec_warn_less ynh_exec_as "$app" RAILS_ENV=production COREPACK_ENABLE_DOWNLOAD_PROMPT=0 "$ynh_ruby_load_path" $ld_preload bin/bundle exec rails db:migrate --quiet
+	ynh_exec_warn_less ynh_exec_as "$app" RAILS_ENV=production COREPACK_ENABLE_DOWNLOAD_PROMPT=0 "$ynh_ruby_load_path" $ld_preload bin/bundle exec rails db:seed --quiet
 	ynh_exec_warn_less ynh_exec_as "$app" RAILS_ENV=production COREPACK_ENABLE_DOWNLOAD_PROMPT=0 "$ynh_ruby_load_path" $ld_preload bin/bundle exec rails assets:precompile --quiet
 	# Generate vapid keys
 	ynh_exec_warn_less ynh_exec_as "$app" RAILS_ENV=production COREPACK_ENABLE_DOWNLOAD_PROMPT=0 "$ynh_ruby_load_path" $ld_preload bin/bundle exec rake mastodon:webpush:generate_vapid_key > key.txt


### PR DESCRIPTION
## Problem

Recent CI has been failing due to a step in the install script - when creating the admin account, the role Owner cannot be found. The latest updates also appear as critical within the admin view of a glitch-soc instance.

## Solution
A solution was found here https://github.com/mastodon/mastodon/issues/18813#issuecomment-1484284987 where the database needs to be seeded with the roles before an admin user is created. The line `ynh_exec_warn_less ynh_exec_as "$app" RAILS_ENV=production COREPACK_ENABLE_DOWNLOAD_PROMPT=0 "$ynh_ruby_load_path" $ld_preload bin/bundle exec rails db:seed --quiet` has been added.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

Tested locally with package_checker

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
