### PR TITLE
Upgrade to 2025.05.31 and migrate redis namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It shall NOT be edited by hand.
 Libre and federated social network, fork of Mastodon
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://glitch-soc.github.io/docs/)
-[![Version: 2025.04.25~ynh1](https://img.shields.io/badge/Version-2025.04.25~ynh1-rgba(0,150,0,1)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/glitchsoc/)
+[![Version: 2025.05.04~ynh1](https://img.shields.io/badge/Version-2025.05.04~ynh1-rgba(0,150,0,1)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/glitchsoc/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/glitchsoc"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/conf/.env.production.sample
+++ b/conf/.env.production.sample
@@ -45,7 +45,6 @@ LOCAL_DOMAIN=__DOMAIN__
 # -----
 REDIS_HOST=localhost
 REDIS_PORT=6379
-REDIS_NAMESPACE=__REDIS_NAMESPACE__
 
 
 # PostgreSQL
@@ -62,6 +61,7 @@ DB_PORT=5432
 #ES_ENABLED=true
 #ES_HOST=localhost
 #ES_PORT=9200
+#ES_PREFIX=
 
 
 # Secrets

--- a/manifest.toml
+++ b/manifest.toml
@@ -55,6 +55,13 @@ ram.runtime = "500M"
 
         autoupdate.strategy = "latest_github_commit"
 
+        [resources.sources.redis_migration]
+        url = "https://raw.githubusercontent.com/mastodon/redis_namespace_migration/refs/heads/main/rename.rb"
+        sha256 = "3134a5c7e0157ee752f5cb49b942c89480951e94236b03dd1cb3cb1d3afdcdd2"
+        in_subdir = false
+        extract = false
+        rename = "rename.rb"
+
     [resources.system_user]
     allow_email = true
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Glitch-Soc"
 description.en = "Libre and federated social network, fork of Mastodon"
 description.fr = "Réseau social libre et fédéré, scission de Mastodon"
 
-version = "2025.04.25~ynh1"
+version = "2025.05.04~ynh1"
 
 maintainers = ["Tagada"]
 
@@ -50,8 +50,8 @@ ram.runtime = "500M"
 [resources]
     [resources.sources]
         [resources.sources.main]
-        url = "https://github.com/glitch-soc/mastodon/archive/42ae13058d450dc0e9b77c5c6c9a89527f0cb3d5.tar.gz"
-        sha256 = "3a864d466015995a1cd297417dae8cba69e7b6b91b34ee932b959e96c202fe56"
+        url = "https://github.com/glitch-soc/mastodon/archive/8b42ec1cfb5d741864bce27aaf6e5449e2fab895.tar.gz"
+        sha256 = "e817cc916f4094d3252d33b82a88222dfc15bb8cc5e9ba874c6057d2efd0b078"
 
         autoupdate.strategy = "latest_github_commit"
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -74,7 +74,7 @@ ram.runtime = "500M"
     stream.default = 4000
 
     [resources.apt]
-    packages = "libvist42, imagemagick, ffmpeg, libpq-dev, libxml2-dev, libxslt1-dev, file, git, git-core, g++, libprotobuf-dev, protobuf-compiler, pkg-config, gcc, autoconf, bison, build-essential, libssl-dev, libyaml-dev, libreadline6-dev, zlib1g-dev, libncurses5-dev, libffi-dev, libgdbm6, libgdbm-dev, redis-tools, redis-server, postgresql, postgresql-contrib, libidn11-dev, libicu-dev, libjemalloc-dev, curl, apt-transport-https"
+    packages = "libvips42, imagemagick, ffmpeg, libpq-dev, libxml2-dev, libxslt1-dev, file, git, git-core, g++, libprotobuf-dev, protobuf-compiler, pkg-config, gcc, autoconf, bison, build-essential, libssl-dev, libyaml-dev, libreadline6-dev, zlib1g-dev, libncurses5-dev, libffi-dev, libgdbm6, libgdbm-dev, redis-tools, redis-server, postgresql, postgresql-contrib, libidn11-dev, libicu-dev, libjemalloc-dev, curl, apt-transport-https"
 
         [resources.apt.extras.yarn]
         repo = "deb https://dl.yarnpkg.com/debian/ stable main"

--- a/manifest.toml
+++ b/manifest.toml
@@ -74,7 +74,7 @@ ram.runtime = "500M"
     stream.default = 4000
 
     [resources.apt]
-    packages = "imagemagick, ffmpeg, libpq-dev, libxml2-dev, libxslt1-dev, file, git, git-core, g++, libprotobuf-dev, protobuf-compiler, pkg-config, gcc, autoconf, bison, build-essential, libssl-dev, libyaml-dev, libreadline6-dev, zlib1g-dev, libncurses5-dev, libffi-dev, libgdbm6, libgdbm-dev, redis-tools, redis-server, postgresql, postgresql-contrib, libidn11-dev, libicu-dev, libjemalloc-dev, curl, apt-transport-https"
+    packages = "libvist42, imagemagick, ffmpeg, libpq-dev, libxml2-dev, libxslt1-dev, file, git, git-core, g++, libprotobuf-dev, protobuf-compiler, pkg-config, gcc, autoconf, bison, build-essential, libssl-dev, libyaml-dev, libreadline6-dev, zlib1g-dev, libncurses5-dev, libffi-dev, libgdbm6, libgdbm-dev, redis-tools, redis-server, postgresql, postgresql-contrib, libidn11-dev, libicu-dev, libjemalloc-dev, curl, apt-transport-https"
 
         [resources.apt.extras.yarn]
         repo = "deb https://dl.yarnpkg.com/debian/ stable main"

--- a/scripts/install
+++ b/scripts/install
@@ -41,9 +41,6 @@ ynh_app_setting_set --app="$app" --key="max_remote_emoji_size" --value="$max_rem
 # Set `service` settings to support `yunohost app shell` command
 ynh_app_setting_set --app="$app" --key=service --value="$app-web.service"
 
-redis_namespace=${app}_production
-ynh_app_setting_set --app="$app" --key=redis_namespace --value="$redis_namespace"
-
 secret_key_base=$(ynh_string_random --length=128)
 ynh_app_setting_set --app="$app" --key=secret_key_base --value="$secret_key_base"
 
@@ -92,6 +89,7 @@ ynh_script_progression --message="Setting up source files..." --weight=1
 
 # Download, check integrity, uncompress and patch the source from app.src
 ynh_setup_source --dest_dir="$install_dir/live"
+ynh_setup_source --source_id=redis_migration --dest_dir="$install_dir/live"
 
 chown -R "$app:www-data" "$install_dir"
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -83,6 +83,8 @@ ynh_script_progression --message="Upgrading source files..." --weight=1
 
 # Download Mastodon
 ynh_setup_source --dest_dir="$install_dir/live" --full_replace=1 --keep="public/system/"
+# Download redis migration script
+ynh_setup_source --source_id=redis_migration --dest_dir="$install_dir/live"
 
 chmod -R o-rwx "$install_dir"
 chown -R "$app:www-data" "$install_dir"
@@ -134,6 +136,17 @@ pushd "$install_dir/live"
 	ynh_use_ruby
 	ynh_exec_warn_less ynh_exec_as "$app" RAILS_ENV=production COREPACK_ENABLE_DOWNLOAD_PROMPT=0 "$ynh_ruby_load_path" $ld_preload bin/bundle exec rails db:migrate
 	ynh_exec_warn_less ynh_exec_as "$app" RAILS_ENV=production COREPACK_ENABLE_DOWNLOAD_PROMPT=0 "$ynh_ruby_load_path" $ld_preload bin/tootctl cache clear
+
+	# Apply redis namespace migration (https://github.com/mastodon/redis_namespace_migration)
+	ynh_exec_warn_less ynh_exec_as "$app" RAILS_ENV=production COREPACK_ENABLE_DOWNLOAD_PROMPT=0 "$ynh_ruby_load_path" $ld_preload bin/rails runner rename.rb
+	redis_namespace="$(ynh_app_setting_get --app=$app --key=redis_namespace)"
+	if [ $redis_namespace ]; then
+		if [ ynh_app_setting_get --app=$app --key=es_enabled == "true" ] && [ ynh_app_setting_get --app=$app --key=es_prefix == "" ]; then
+			ynh_app_setting_set --app=$app --key=es_prefix --value=$redis_namespace
+		else
+			ynh_app_setting_delete --app=$app --key=redis_namespace
+		fi
+	fi
 popd
 
 #=================================================


### PR DESCRIPTION
## Problem

Recent automated upgrade branches have been failing due to redis namespace deprecation.

```
516325 INFO    DEBUG - I, [2025-06-01T22:35:32.161285 #30920]  INFO -- : [dotenv] Loaded .env.production
516325 INFO    DEBUG - ERROR: the REDIS_NAMESPACE environment variable is no longer supported, and a migration is required.
516325 INFO    DEBUG -
516325 INFO    DEBUG - Please see documentation at https://github.com/mastodon/redis_namespace_migration
```

## Solution

Following the instructions outlined here https://github.com/mastodon/redis_namespace_migration for Case 1: Keep Redis Database, Only Remove Namespace, the linked rename.rb script has been added as a source and run during upgrade, and the REDIS_NAMESPACE variable in .env.production is either moved to ES_PREFIX or removed, based on whether Elasticsearch is enabled and ES_PREFIX is not already set.
## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
