### PR TITLE
critical security patch (2026.07.27)

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Glitch-Soc"
 description.en = "Libre and federated social network, fork of Mastodon"
 description.fr = "Réseau social libre et fédéré, scission de Mastodon"
 
-version = "2026.07.24~ynh1"
+version = "2026.07.27~ynh1"
 
 maintainers = []
 
@@ -50,8 +50,8 @@ ram.runtime = "500M"
 [resources]
     [resources.sources]
         [resources.sources.main]
-        url = "https://github.com/glitch-soc/mastodon/archive/284359bc778bb5803c21273503e033cf5c517583.tar.gz"
-        sha256 = "3b4277b234a6e3e18a045517b747f59635241cd5194fbd03721e2c7e706b110f"
+        url = "https://github.com/glitch-soc/mastodon/archive/833599e06496f48a537591b7a776ed64c675c027.tar.gz"
+        sha256 = "1b04fe4202d17efd686d0feef5f195f993c1d13583325de65bd22298653ee8f8"
 
         autoupdate.strategy = "latest_github_commit"
 


### PR DESCRIPTION
https://github.com/glitch-soc/mastodon/releases/tag/v4.6.4

- Fix incorrect permission enforcement ([GHSA-7jvv-fhmg-wpfw](https://github.com/mastodon/mastodon/security/advisories/GHSA-7jvv-fhmg-wpfw), [GHSA-hx34-2pfw-2qfj](https://github.com/mastodon/mastodon/security/advisories/GHSA-hx34-2pfw-2qfj))
- Fix SSRF protection bypass via IPv4-compatible IPv6 addresses ([GHSA-vwhj-3g83-v276](https://github.com/mastodon/mastodon/security/advisories/GHSA-vwhj-3g83-v276))

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
